### PR TITLE
Fix two default values in the workspace config and toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ evercrypt-sys = { path = "evercrypt-rust/evercrypt-sys" }
 key_store = { path = "key-store-rs" }
 
 [patch.'https://github.com/franziskuskiefer/algorithm-identifiers-rs.git']
-algorithm_identifiers = { path = "algorithm-identifiers-rs" }
+crypto_algorithms = { path = "algorithm-identifiers-rs" }
 
 [patch.crates-io]
 evercrypt = { path = "evercrypt-rust/evercrypt-rs" }

--- a/config
+++ b/config
@@ -6,5 +6,5 @@ algorithm_identifiers_rs_branch=main
 key_store_rs_branch=main
 hpke_rs_branch=openmls-crypto
 crypto_branch=main
-openmls_branch=workspace-reorg
 tls_codec_branch=main
+openmls_branch=main


### PR DESCRIPTION
In particular, fix the crate name for the crypto algorithms/identifiers and set the openmls branch to master by default.